### PR TITLE
Set dask packages version

### DIFF
--- a/rut-spring-2022/environment.yml
+++ b/rut-spring-2022/environment.yml
@@ -17,5 +17,6 @@
    - boto3
    - botocore
    - jupyterlab
-   - dask
-   - dask-gateway=0.8.0
+   - dask=2.30.0
+   - distributed=2.30.0
+   - dask-gateway=0.9.0


### PR DESCRIPTION
Following https://zonca.dev/2022/01/dask-gateway-jupyterhub.html, using `dask` 2.30.0 and `dask-gateway` 0.9.0

See https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/issues/47